### PR TITLE
Fix elevator block and passenger movement desync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,8 @@ buildNumber.properties
 
 # Common working directory
 run/
+
+# Test server
+testserver/*
+!testserver/start.bat
+!testserver/eula.txt

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,13 @@
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <mockito.version>5.11.0</mockito.version>
     </properties>
 
     <build>
         <defaultGoal>clean package</defaultGoal>
+        <testSourceDirectory>${project.basedir}/tests</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -27,6 +30,11 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -122,6 +130,49 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Testing Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
+            <artifactId>mockbukkit-v1.21</artifactId>
+            <version>4.108.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-chat</artifactId>
+            <version>1.20-R0.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -94,13 +94,28 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.10-R0.1-SNAPSHOT</version>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+            <!-- Exclude unnecessary/vulnerable transitive dependencies -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.md-5</groupId>
+                    <artifactId>bungeecord-chat</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.elvenide</groupId>
             <artifactId>ElvenideCore</artifactId>
-            <version>0.0.17</version>
+            <version>25.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.papermc.paper</groupId>

--- a/src/main/java/com/elvenide/structures/ElvenideStructures.java
+++ b/src/main/java/com/elvenide/structures/ElvenideStructures.java
@@ -25,7 +25,9 @@ public final class ElvenideStructures extends JavaPlugin {
 
     @Override
     public void onLoad() {
-        Core.text.packages.moreColors.install();
+        Core.text.packages.install(
+            Core.text.packages.moreColors
+        );
     }
 
     @Override
@@ -34,7 +36,9 @@ public final class ElvenideStructures extends JavaPlugin {
 
         File dataFolder = getDataFolder();
         if (!dataFolder.exists()) {
-            dataFolder.mkdirs();
+            boolean success = dataFolder.mkdirs();
+            if (!success)
+                throw new IllegalStateException("An unknown error prevented the ElvenideStructures plugin from creating its plugin folder.");
         }
 
         Core.plugin.registerListeners(elevatorManager); // Register Bukkit listener for elevators
@@ -46,20 +50,14 @@ public final class ElvenideStructures extends JavaPlugin {
         Core.commands.create("elvenidestructures")
             .setAliases("estructures", "estruct")
             .setDescription("<dark_aqua>Create moving structures!")
-            .addSubGroup("elevator", builder -> {
-                builder
-                    .addSubCommand(new ElevatorCreateCommand())
-                    .addSubCommand(new ElevatorDeleteCommand())
-                    .addSubCommand(new ElevatorRunCommand());
-            })
-            .addSubGroup("door", builder -> {
-                builder
-                    .addSubGroup("create", create -> {
-                        create
-                            .addSubCommand(new SlidingDoorCommand());
-                    })
-                    .addSubCommand(new DoorDeleteCommand());
-            })
+            .addSubGroup("elevator", builder -> builder
+                .addSubCommand(new ElevatorCreateCommand())
+                .addSubCommand(new ElevatorDeleteCommand())
+                .addSubCommand(new ElevatorRunCommand()))
+            .addSubGroup("door", builder -> builder
+                .addSubGroup("create", create -> create
+                    .addSubCommand(new SlidingDoorCommand()))
+                .addSubCommand(new DoorDeleteCommand()))
             .addSubCommand(new SubCommand() {
                 @Override
                 public @NotNull String label() {

--- a/src/main/java/com/elvenide/structures/Keys.java
+++ b/src/main/java/com/elvenide/structures/Keys.java
@@ -1,5 +1,7 @@
 package com.elvenide.structures;
 
-public enum Keys {
+import com.elvenide.core.providers.key.CoreKey;
+
+public enum Keys implements CoreKey {
     SELECTION_TOOL
 }

--- a/src/main/java/com/elvenide/structures/Structure.java
+++ b/src/main/java/com/elvenide/structures/Structure.java
@@ -1,5 +1,6 @@
 package com.elvenide.structures;
 
+import com.elvenide.core.api.PublicAPI;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -7,6 +8,7 @@ public interface Structure {
 
     void onNearbySwitchUsed(Player user, Location loc);
 
+    @PublicAPI
     boolean isNearby(Location loc);
 
 }

--- a/src/main/java/com/elvenide/structures/StructureManager.java
+++ b/src/main/java/com/elvenide/structures/StructureManager.java
@@ -1,6 +1,7 @@
 package com.elvenide.structures;
 
 import com.elvenide.core.Core;
+import com.elvenide.core.api.PublicAPI;
 import com.elvenide.core.providers.config.Config;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -8,6 +9,8 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
 public interface StructureManager<T extends Structure> {
+
+    @PublicAPI
     @Nullable T getNearby(Location loc);
 
     default Config getStructures(World world) {

--- a/src/main/java/com/elvenide/structures/doors/types/SlidingDoor.java
+++ b/src/main/java/com/elvenide/structures/doors/types/SlidingDoor.java
@@ -30,8 +30,8 @@ public class SlidingDoor implements Door {
         if (!config.contains("locations"))
             return blocks;
 
-        for (String key : config.getSection("locations").getKeys()) {
-            blocks.add(config.getSection("locations").getLocation(key));
+        for (String key : config.getSectionOrThrow("locations").getKeys()) {
+            blocks.add(config.getSectionOrThrow("locations").getLocation(key));
         }
         return blocks;
     }

--- a/src/main/java/com/elvenide/structures/elevators/Elevator.java
+++ b/src/main/java/com/elvenide/structures/elevators/Elevator.java
@@ -23,6 +23,7 @@ public class Elevator implements Structure {
     private final ConfigSection config;
     private final ArrayList<Location> carriageLocations = new ArrayList<>();
     private final HashSet<ElevatorBlock> elevatorBlocks = new HashSet<>();
+    private final HashSet<LivingEntity> passengers = new HashSet<>();
     private boolean isMoving = false;
     private long cooldown = 0;
     Player moveDelayTrigger = null;
@@ -87,7 +88,7 @@ public class Elevator implements Structure {
 
     /// Get all passengers known to be riding this elevator when it was last moving
     public Set<LivingEntity> getLastKnownPassengers() {
-        return getElevatorBlocks().stream().map(ElevatorBlock::getLastKnownPassengers).flatMap(HashSet::stream).collect(Collectors.toSet());
+        return passengers;
     }
 
     /// Get all passengers currently standing inside this elevator
@@ -269,6 +270,13 @@ public class Elevator implements Structure {
         int currentY = getCurrentY();
         int direction = (targetY > currentY ? 1 : -1);
 
+        // Calculate initial passengers list
+        passengers.clear();
+        for (LivingEntity e : getCurrentlyInside()) {
+            ElevatorUtils.freezePassengerMovement(e);
+            passengers.add(e);
+        }
+
         for (ElevatorBlock block : getElevatorBlocks())
             block.spawn(targetY);
 
@@ -276,6 +284,26 @@ public class Elevator implements Structure {
             ElevatorBlock elevatorBlock = getElevatorBlocks().iterator().next();
             if (elevatorBlock.atDestination || !elevatorBlock.isValid()) {
                 getElevatorBlocks().forEach(ElevatorBlock::end);
+                
+                // End passenger movement
+                for (LivingEntity e : passengers) {
+                    ElevatorUtils.unfreezePassengerMovement(e);
+                }
+
+                for (ElevatorBlock b : getElevatorBlocks()) {
+                    if (b.isFloorBlock()) {
+                        for (LivingEntity e : b.getEntitiesInsideBlock()) {
+                            Location entityLoc = e.getLocation();
+                            double teleportY = b.targetY + 1.01;
+                            entityLoc.setY(teleportY);
+                            if (e.getVehicle() != null)
+                                e.getVehicle().teleport(entityLoc);
+                            else
+                                e.teleport(entityLoc);
+                        }
+                    }
+                }
+
                 setCurrentY(elevatorBlock.getCurrentY());
                 isMoving = false;
                 task.cancel();
@@ -283,22 +311,52 @@ public class Elevator implements Structure {
                 return;
             }
 
+            // Determine distance actually moved
             double actualMove = 0;
             for (ElevatorBlock block : getElevatorBlocks()) {
                 actualMove = block.move(direction);
             }
+            final double finalActualMove = actualMove;
 
-            // Handle player passengers
-            double finalActualMove = actualMove;
-            getLastKnownPassengers().forEach(e -> {
+            // Get new passengers and disable their movement/gravity
+            HashSet<LivingEntity> newPassengers = new HashSet<>(getCurrentlyInside());
+            for (LivingEntity e : newPassengers) {
+                if (!passengers.contains(e)) {
+                    ElevatorUtils.freezePassengerMovement(e);
+                }
+            }
+
+            // Remove old passengers that are too far away
+            HashSet<LivingEntity> toRemove = new HashSet<>();
+            passengers.forEach(e -> {
+                boolean tooFar = true;
+                for (ElevatorBlock b : getElevatorBlocks()) {
+                    if (b.isFloorBlock() && e.getLocation().getWorld() == b.getCurrentLocation().getWorld() 
+                        && e.getLocation().distanceSquared(b.getCurrentLocation()) <= 3 * 3) {
+                        tooFar = false;
+                        break;
+                    }
+                }
+                if (tooFar) {
+                    toRemove.add(e);
+                    ElevatorUtils.unfreezePassengerMovement(e);
+                }
+            });
+            passengers.removeAll(toRemove);
+
+            // Update passengers with new ones
+            passengers.addAll(newPassengers);
+
+            // Handle passengers
+            for (LivingEntity e : passengers) {
+                e.setFallDistance(0);
+                e.setVelocity(new Vector(0, finalActualMove, 0));
+
                 if (e instanceof Player p) {
-                    p.setFallDistance(0);
-                    p.setVelocity(new Vector(0, finalActualMove, 0));
-
                     // Re-enable flying every tick to prevent the player from manually disabling it
                     p.setFlying(true);
                 }
-            });
+            }
         })
         .repeat(0L, 1L);
     }

--- a/src/main/java/com/elvenide/structures/elevators/Elevator.java
+++ b/src/main/java/com/elvenide/structures/elevators/Elevator.java
@@ -43,8 +43,8 @@ public class Elevator implements Structure {
         if (!config.contains("locations"))
             return carriageLocations;
 
-        for (String key : config.getSection("locations").getKeys()) {
-            carriageLocations.add(config.getSection("locations").getLocation(key));
+        for (String key : config.getSectionOrThrow("locations").getKeys()) {
+            carriageLocations.add(config.getSectionOrThrow("locations").getLocation(key));
         }
         return carriageLocations;
     }
@@ -100,7 +100,7 @@ public class Elevator implements Structure {
     public int getCarriageSize() {
         if (!config.contains("locations"))
             return 0;
-        return config.getSection("locations").getKeys().size();
+        return config.getSectionOrThrow("locations").getKeys().size();
     }
 
     /// Get the base floor Y level of this elevator

--- a/src/main/java/com/elvenide/structures/elevators/Elevator.java
+++ b/src/main/java/com/elvenide/structures/elevators/Elevator.java
@@ -283,7 +283,7 @@ public class Elevator implements Structure {
                 return;
             }
 
-            double actualMove = elevatorBlock.getBlocksPerTick(direction);
+            double actualMove = 0;
             for (ElevatorBlock block : getElevatorBlocks()) {
                 actualMove = block.move(direction);
             }

--- a/src/main/java/com/elvenide/structures/elevators/Elevator.java
+++ b/src/main/java/com/elvenide/structures/elevators/Elevator.java
@@ -283,14 +283,17 @@ public class Elevator implements Structure {
                 return;
             }
 
-            getElevatorBlocks().forEach(block -> block.move(direction));
+            double actualMove = elevatorBlock.getBlocksPerTick(direction);
+            for (ElevatorBlock block : getElevatorBlocks()) {
+                actualMove = block.move(direction);
+            }
 
             // Handle player passengers
-            double blocksPerTick = elevatorBlock.getBlocksPerTick(direction);
+            double finalActualMove = actualMove;
             getLastKnownPassengers().forEach(e -> {
                 if (e instanceof Player p) {
                     p.setFallDistance(0);
-                    p.setVelocity(new Vector(0, blocksPerTick, 0));
+                    p.setVelocity(new Vector(0, finalActualMove, 0));
 
                     // Re-enable flying every tick to prevent the player from manually disabling it
                     p.setFlying(true);

--- a/src/main/java/com/elvenide/structures/elevators/Elevator.java
+++ b/src/main/java/com/elvenide/structures/elevators/Elevator.java
@@ -283,7 +283,7 @@ public class Elevator implements Structure {
                 return;
             }
 
-            double actualMove = 0;
+            double actualMove = elevatorBlock.getBlocksPerTick(direction);
             for (ElevatorBlock block : getElevatorBlocks()) {
                 actualMove = block.move(direction);
             }

--- a/src/main/java/com/elvenide/structures/elevators/ElevatorBlock.java
+++ b/src/main/java/com/elvenide/structures/elevators/ElevatorBlock.java
@@ -71,22 +71,25 @@ public class ElevatorBlock {
         return parent.getSpeed() * direction / 20.0;
     }
 
-    public void move(double direction) {
+    public double move(double direction) {
         double blocksPerTick = getBlocksPerTick(direction);
 
         double prevY = getCurrentLocation().getY();
         double y = prevY + blocksPerTick;
-        if ((prevY < targetY && y > targetY) || (prevY > targetY && y < targetY)) {
-            // Reset y
+        if (direction > 0 && y >= targetY) {
+            y = targetY;
+        } else if (direction < 0 && y <= targetY) {
             y = targetY;
         }
 
         // Check if at destination
         atDestination = y == targetY;
 
+        double actualMove = y - prevY;
+
         // Move elevator
         setCurrentY(y);
-        blockEntity().setVelocity(new Vector(0, blocksPerTick, 0));
+        blockEntity().setVelocity(new Vector(0, actualMove, 0));
 
         // Move any entities on elevator
         if (isFloorBlock()) {
@@ -134,13 +137,15 @@ public class ElevatorBlock {
                 }
             }
         }
+
+        return actualMove;
     }
 
     public void end() {
         if (isFloorBlock()) {
             for (LivingEntity e : getEntitiesInsideBlock()) {
                 Location entityLoc = e.getLocation();
-                double teleportY = getCurrentLocation().getBlockY() + 1.01;
+                double teleportY = targetY + 1.01;
                 entityLoc.setY(teleportY);
                 if (e.getVehicle() != null)
                     e.getVehicle().teleport(entityLoc);
@@ -154,16 +159,20 @@ public class ElevatorBlock {
             }
         }
 
-        getCurrentLocation().toBlockLocation().getBlock().setBlockData(blockData, false);
+        Location finalLoc = getCurrentLocation().toBlockLocation();
+        finalLoc.setY(targetY);
+        finalLoc.getBlock().setBlockData(blockData, false);
 
         if (blockEntity() != null)
             blockEntity().remove();
 
+        // Update current location to exact target
+        currentLocation.setY(targetY);
         atDestination = false;
     }
 
     public int getCurrentY() {
-        return getCurrentLocation().getBlockY() - baseDifference;
+        return (int) Math.round(getCurrentLocation().getY()) - baseDifference;
     }
 
     public boolean isValid() {

--- a/src/main/java/com/elvenide/structures/elevators/ElevatorBlock.java
+++ b/src/main/java/com/elvenide/structures/elevators/ElevatorBlock.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 public class ElevatorBlock {
@@ -16,9 +15,8 @@ public class ElevatorBlock {
     private FallingBlock block;
     private final Location currentLocation;
     private final Elevator parent;
-    private final HashSet<LivingEntity> passengers = new HashSet<>();
     private final int baseDifference;
-    private int targetY;
+    int targetY;
     private final boolean isFloorBlock;
     public boolean atDestination = false;
 
@@ -30,7 +28,7 @@ public class ElevatorBlock {
         this.isFloorBlock = isFloorBlock;
     }
 
-    private Location getCurrentLocation() {
+    Location getCurrentLocation() {
         return currentLocation;
     }
 
@@ -43,14 +41,6 @@ public class ElevatorBlock {
     }
 
     public void spawn(int targetY) {
-        passengers.clear();
-
-        if (isFloorBlock())
-            for (LivingEntity e : getEntitiesOnBlock()) {
-                ElevatorUtils.freezePassengerMovement(e);
-                passengers.add(e);
-            }
-
         this.blockData = getCurrentLocation().getBlock().getBlockData();
         getCurrentLocation().toBlockLocation().getBlock().setBlockData(Material.AIR.createBlockData(), false);
 
@@ -91,74 +81,10 @@ public class ElevatorBlock {
         setCurrentY(y);
         blockEntity().setVelocity(new Vector(0, actualMove, 0));
 
-        // Move any entities on elevator
-        if (isFloorBlock()) {
-            // Get new passengers and disable their movement/gravity
-            HashSet<LivingEntity> newPassengers = new HashSet<>(getEntitiesOnBlock());
-            for (LivingEntity e : newPassengers) {
-                if (!passengers.contains(e)) {
-                    ElevatorUtils.freezePassengerMovement(e);
-                }
-            }
-
-            // Remove old passengers that are too far away
-            HashSet<LivingEntity> toRemove = new HashSet<>();
-            passengers.forEach(e -> {
-                if (e.getLocation().getWorld() != getCurrentLocation().getWorld()
-                    || e.getLocation().distanceSquared(getCurrentLocation()) > 3 * 3) {
-                    toRemove.add(e);
-                    ElevatorUtils.unfreezePassengerMovement(e);
-                }
-            });
-            passengers.removeAll(toRemove);
-
-            // Update passengers with new ones
-            passengers.addAll(newPassengers);
-
-            // Handle current non-player passengers
-            for (LivingEntity e : passengers) {
-                if (!(e instanceof Player)) {
-                    // Always teleport non-players
-
-                    e.setFallDistance(0);
-                    Location entityLoc = e.getLocation();
-                    double teleportY = y + 1;
-
-                    if (direction > 0)
-                        teleportY += 0.15;
-                    else
-                        teleportY -= 0.15;
-
-                    entityLoc.setY(teleportY);
-                    if (e.getVehicle() != null)
-                        e.getVehicle().teleport(entityLoc);
-                    else
-                        e.teleport(entityLoc);
-                }
-            }
-        }
-
         return actualMove;
     }
 
     public void end() {
-        if (isFloorBlock()) {
-            for (LivingEntity e : getEntitiesInsideBlock()) {
-                Location entityLoc = e.getLocation();
-                double teleportY = targetY + 1.01;
-                entityLoc.setY(teleportY);
-                if (e.getVehicle() != null)
-                    e.getVehicle().teleport(entityLoc);
-                else
-                    e.teleport(entityLoc);
-            }
-
-            // Deal with passengers who are getting off the elevator
-            for (LivingEntity e : passengers) {
-                ElevatorUtils.unfreezePassengerMovement(e);
-            }
-        }
-
         Location finalLoc = getCurrentLocation().toBlockLocation();
         finalLoc.setY(targetY);
         finalLoc.getBlock().setBlockData(blockData, false);
@@ -192,13 +118,6 @@ public class ElevatorBlock {
     public List<LivingEntity> getEntitiesInsideBlock() {
         Location horizontalCenter = getCurrentLocation().toCenterLocation();
         return new ArrayList<>(horizontalCenter.getNearbyLivingEntities(0.5, 0.5, 0.5));
-    }
-
-    /**
-     * Unlike getEntitiesOnBlock, this only returns entities that were last in the elevator when it was moving
-     */
-    public HashSet<LivingEntity> getLastKnownPassengers() {
-        return passengers;
     }
 
 }

--- a/src/main/java/com/elvenide/structures/selection/SelectionTool.java
+++ b/src/main/java/com/elvenide/structures/selection/SelectionTool.java
@@ -3,7 +3,6 @@ package com.elvenide.structures.selection;
 import com.elvenide.core.Core;
 import com.elvenide.core.api.PublicAPI;
 import com.elvenide.core.providers.item.ItemBuilder;
-import com.elvenide.structures.ElvenideStructures;
 import com.elvenide.structures.Keys;
 import com.elvenide.structures.selection.events.SelectionCancelEvent;
 import com.elvenide.structures.selection.events.SelectionEvent;
@@ -17,6 +16,7 @@ import org.bukkit.event.player.*;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -36,7 +36,7 @@ public abstract class SelectionTool implements Listener {
         this.uuid = UUID.randomUUID();
         ItemBuilder builder = create(Core.items.create(Material.NETHERITE_AXE)
             .name("<smooth_purple>Elvenide's Selection Tool")
-            .data(Keys.SELECTION_TOOL, PersistentDataType.STRING, uuid.toString())
+            .data(Keys.SELECTION_TOOL.get(), PersistentDataType.STRING, uuid.toString())
             .lore("<yellow>Left-click <gray>to select corner #1")
             .lore("<yellow>Right-click <gray>to select corner #2"));
         builder.lore("<yellow>Press F <gray>to complete selection");
@@ -56,7 +56,7 @@ public abstract class SelectionTool implements Listener {
     public boolean is(ItemStack item) {
         if (item == null || !item.hasItemMeta())
             return false;
-        return Core.items.getData(item, Keys.SELECTION_TOOL, PersistentDataType.STRING, "").equals(uuid.toString());
+        return Core.items.getData(item, Keys.SELECTION_TOOL.get(), PersistentDataType.STRING, "").equals(uuid.toString());
     }
 
     /// Returns false if the corner is already selected
@@ -99,6 +99,7 @@ public abstract class SelectionTool implements Listener {
     }
 
     /// Called when the player left-clicks a block
+    @ApiStatus.OverrideOnly
     protected void onLeftClick(Block block, Player player) {
         Location l = block.getLocation();
         if (!selectCorner1(l))
@@ -112,6 +113,7 @@ public abstract class SelectionTool implements Listener {
     }
 
     /// Called when the player right-clicks a block
+    @ApiStatus.OverrideOnly
     protected void onRightClick(Block block, Player player) {
         Location l = block.getLocation();
         if (!selectCorner2(l))
@@ -125,26 +127,32 @@ public abstract class SelectionTool implements Listener {
     }
 
     /// Called when the player shift-left-clicks a block
+    @SuppressWarnings({ "unused", "EmptyMethod" })
+    @ApiStatus.OverrideOnly
     protected void onShiftLeftClick(Block block, Player player) {
         // Does nothing by default
     }
 
     /// Called when the player shift-left-clicks, whether a block or not
+    @ApiStatus.OverrideOnly
     protected void onShiftLeftClick(Player player) {
         // Does nothing by default
     }
 
     /// Called when the player shift-right-clicks a block
+    @ApiStatus.OverrideOnly
     protected void onShiftRightClick(Block block, Player player) {
         // Does nothing by default
     }
 
     /// Called when the player shift-right-clicks, whether a block or not
+    @ApiStatus.OverrideOnly
     protected void onShiftRightClick(Player player) {
         // Does nothing by default
     }
 
     /// Called when the player presses F (offhand swap)
+    @ApiStatus.OverrideOnly
     protected void onFPress(Player player) {
         Selection selection = getSelection();
         @Nullable String error = getCompletionError();

--- a/src/main/java/com/elvenide/structures/selection/events/SelectionEvent.java
+++ b/src/main/java/com/elvenide/structures/selection/events/SelectionEvent.java
@@ -3,9 +3,6 @@ package com.elvenide.structures.selection.events;
 import com.elvenide.core.providers.event.CoreEvent;
 import com.elvenide.structures.selection.Selection;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public record SelectionEvent(Selection selection, Player selector) implements CoreEvent {
 }

--- a/tests/com/elvenide/structures/CoreMock.java
+++ b/tests/com/elvenide/structures/CoreMock.java
@@ -1,0 +1,33 @@
+package com.elvenide.structures;
+
+import com.elvenide.core.Core;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CoreMock {
+
+    public static MockedStatic<Core> mockCore() {
+        MockedStatic<Core> mockedCore = Mockito.mockStatic(Core.class);
+        
+        // Try to initialize ElvenideCore via Core.plugin.set()
+        if (Core.plugin != null) {
+            JavaPlugin mockPlugin = mock(JavaPlugin.class);
+            try {
+                File tempDir = Files.createTempDirectory("elvenide-test").toFile();
+                when(mockPlugin.getDataFolder()).thenReturn(tempDir);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            Core.plugin.set(mockPlugin);
+        }
+
+        return mockedCore;
+    }
+}

--- a/tests/com/elvenide/structures/doors/DoorBlockTest.java
+++ b/tests/com/elvenide/structures/doors/DoorBlockTest.java
@@ -1,0 +1,21 @@
+package com.elvenide.structures.doors;
+
+import org.bukkit.Location;
+import org.bukkit.entity.BlockDisplay;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class DoorBlockTest {
+
+    @Test
+    void testDoorBlock() {
+        Location loc = mock(Location.class);
+        BlockDisplay display = mock(BlockDisplay.class);
+        DoorBlock doorBlock = new DoorBlock(loc, display);
+
+        assertEquals(loc, doorBlock.initialLocation());
+        assertEquals(display, doorBlock.display());
+    }
+}

--- a/tests/com/elvenide/structures/doors/DoorManagerTest.java
+++ b/tests/com/elvenide/structures/doors/DoorManagerTest.java
@@ -1,0 +1,67 @@
+package com.elvenide.structures.doors;
+
+import com.elvenide.core.Core;
+import com.elvenide.core.providers.config.Config;
+import com.elvenide.core.providers.config.ConfigSection;
+import com.elvenide.structures.CoreMock;
+import com.elvenide.structures.ElvenideStructures;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Location;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DoorManagerTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private MockedStatic<Core> mockedCore;
+    private DoorManager manager;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        mockedCore = CoreMock.mockCore();
+        manager = new DoorManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedCore.close();
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testGetNearby() {
+        Location loc = new Location(world, 0, 100, 0);
+        
+        Door door = mock(Door.class);
+        when(door.isNearby(loc)).thenReturn(true);
+        
+        manager.add(world, "test-door", door);
+        
+        assertEquals(door, manager.getNearby(loc));
+    }
+
+    @Test
+    void testGetNames() {
+        assertTrue(manager.getNames(world).isEmpty());
+        
+        Door door = mock(Door.class);
+        manager.add(world, "test-door", door);
+        
+        assertEquals(1, manager.getNames(world).size());
+        assertTrue(manager.getNames(world).contains("test-door"));
+    }
+}

--- a/tests/com/elvenide/structures/doors/types/SlidingDoorTest.java
+++ b/tests/com/elvenide/structures/doors/types/SlidingDoorTest.java
@@ -1,0 +1,112 @@
+package com.elvenide.structures.doors.types;
+
+import com.elvenide.core.Core;
+import com.elvenide.core.providers.config.ConfigSection;
+import com.elvenide.structures.CoreMock;
+import com.elvenide.structures.ElvenideStructures;
+import com.elvenide.structures.doors.DoorBlock;
+import com.elvenide.structures.doors.DoorManager;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.util.Transformation;
+import org.bukkit.util.Vector;
+import org.joml.Vector3f;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SlidingDoorTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private MockedStatic<Core> mockedCore;
+    private MockedStatic<ElvenideStructures> mockedStructures;
+    private ConfigSection config;
+    private DoorManager doorManager;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        mockedCore = CoreMock.mockCore();
+        
+        config = mock(ConfigSection.class);
+        doorManager = mock(DoorManager.class);
+        
+        mockedStructures = Mockito.mockStatic(ElvenideStructures.class);
+        mockedStructures.when(ElvenideStructures::doors).thenReturn(doorManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedCore.close();
+        mockedStructures.close();
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testSlidingDoor() {
+        Location loc = new Location(world, 0, 100, 0);
+        loc.getBlock().setType(Material.STONE);
+
+        ConfigSection locsSection = mock(ConfigSection.class);
+        when(config.contains("locations")).thenReturn(true);
+        when(config.getSectionOrThrow("locations")).thenReturn(locsSection);
+        when(locsSection.getKeys()).thenReturn(new HashSet<>(Collections.singletonList("0_100_0")));
+        when(locsSection.getLocation("0_100_0")).thenReturn(loc);
+
+        when(config.getVector("move-direction")).thenReturn(new Vector(0, 1, 0));
+        when(config.getInt("move-distance")).thenReturn(2);
+        when(config.getFloat("move-duration")).thenReturn(1.0f);
+
+        // TODO: fix this test getting skipped due to below line
+        SlidingDoor door = new SlidingDoor(config);
+
+        assertEquals(20, door.getMoveDuration());
+        assertEquals(new Vector(0, 1, 0), door.getMoveDirection());
+        assertEquals(2, door.getMoveDistance());
+        assertEquals(1, door.getBlocks().size());
+
+        DoorBlock block = door.getBlocks().get(0);
+        Transformation trans = door.getTransformationAtPercent(block, 0.5);
+        assertEquals(new Vector3f(0, 1, 0), trans.getTranslation()); // 0.5 * 2 = 1.0 in Y
+    }
+
+    @Test
+    void testOpenClose() {
+        Location loc = new Location(world, 0, 100, 0);
+        loc.getBlock().setType(Material.STONE);
+
+        ConfigSection locsSection = mock(ConfigSection.class);
+        when(config.contains("locations")).thenReturn(true);
+        when(config.getSectionOrThrow("locations")).thenReturn(locsSection);
+        when(locsSection.getKeys()).thenReturn(new HashSet<>(Collections.singletonList("0_100_0")));
+        when(locsSection.getLocation("0_100_0")).thenReturn(loc);
+        when(config.getBoolean("open", false)).thenReturn(false);
+
+        // TODO: fix this test getting skipped due to below line
+        SlidingDoor door = new SlidingDoor(config);
+
+        assertFalse(door.isOpen());
+        assertFalse(door.isMoving());
+
+        door.open();
+        assertTrue(door.isMoving());
+        
+        // Wait for tasks?
+        // Since we mocked Core.tasks to not run immediately, we can't easily test the full movement here
+        // unless we make CoreMock run tasks.
+    }
+}

--- a/tests/com/elvenide/structures/elevators/ElevatorBlockTest.java
+++ b/tests/com/elvenide/structures/elevators/ElevatorBlockTest.java
@@ -1,0 +1,100 @@
+package com.elvenide.structures.elevators;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ElevatorBlockTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private Elevator elevator;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        elevator = mock(Elevator.class);
+        when(elevator.getBaseY()).thenReturn(100);
+        when(elevator.getCurrentY()).thenReturn(100);
+        when(elevator.getSpeed()).thenReturn(1.0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testElevatorBlockConstructor() {
+        Location start = new Location(world, 0, 100, 0);
+        ElevatorBlock eb = new ElevatorBlock(start, elevator, true);
+        assertEquals(start, eb.getCurrentLocation());
+        assertTrue(eb.isFloorBlock());
+        assertEquals(100, eb.getCurrentY());
+    }
+
+    @Test
+    void testSpawn() {
+        Location start = new Location(world, 0, 100, 0);
+        start.getBlock().setType(Material.STONE);
+        ElevatorBlock eb = new ElevatorBlock(start, elevator, true);
+        
+        eb.spawn(110);
+        
+        assertEquals(Material.AIR, start.getBlock().getType());
+        assertNotNull(eb.getCurrentLocation());
+        assertTrue(eb.isValid());
+        assertEquals(110, eb.targetY);
+    }
+
+    @Test
+    void testMoveUp() {
+        Location start = new Location(world, 0, 100, 0);
+        start.getBlock().setType(Material.STONE);
+        ElevatorBlock eb = new ElevatorBlock(start, elevator, true);
+        eb.spawn(105); // Target 105
+
+        // Speed is 1.0, direction 1, tick 1/20 = 0.05
+        double move = eb.move(1);
+        assertEquals(0.05, move, 0.001);
+        assertEquals(100.05, eb.getCurrentLocation().getY(), 0.001);
+        assertFalse(eb.atDestination);
+    }
+
+    @Test
+    void testMoveAtDestination() {
+        Location start = new Location(world, 0, 100, 0);
+        start.getBlock().setType(Material.STONE);
+        ElevatorBlock eb = new ElevatorBlock(start, elevator, true);
+        eb.spawn(101); // Target 101
+
+        when(elevator.getSpeed()).thenReturn(20.0); // 1 block per tick
+        
+        double move = eb.move(1);
+        assertEquals(1.0, move, 0.001);
+        assertEquals(101.0, eb.getCurrentLocation().getY(), 0.001);
+        assertTrue(eb.atDestination);
+    }
+
+    @Test
+    void testEnd() {
+        Location start = new Location(world, 0, 100, 0);
+        start.getBlock().setType(Material.STONE);
+        ElevatorBlock eb = new ElevatorBlock(start, elevator, true);
+        eb.spawn(110);
+        
+        eb.end();
+        
+        assertEquals(Material.STONE, world.getBlockAt(0, 110, 0).getType());
+        assertFalse(eb.isValid());
+    }
+}

--- a/tests/com/elvenide/structures/elevators/ElevatorManagerTest.java
+++ b/tests/com/elvenide/structures/elevators/ElevatorManagerTest.java
@@ -1,0 +1,44 @@
+package com.elvenide.structures.elevators;
+
+import com.elvenide.core.Core;
+import com.elvenide.structures.CoreMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ElevatorManagerTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private MockedStatic<Core> mockedCore;
+    private ElevatorManager manager;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        mockedCore = CoreMock.mockCore();
+        manager = new ElevatorManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedCore.close();
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testCreate() {
+        // We use the real Core.config but it points to a temp directory set up in CoreMock
+        Elevator e = manager.create("test", 1.0, 5.0, world);
+        assertNotNull(e);
+        assertEquals("test", e.getName());
+        assertEquals(1.0, e.getSpeed());
+    }
+}

--- a/tests/com/elvenide/structures/elevators/ElevatorTest.java
+++ b/tests/com/elvenide/structures/elevators/ElevatorTest.java
@@ -1,0 +1,120 @@
+package com.elvenide.structures.elevators;
+
+import com.elvenide.core.Core;
+import com.elvenide.core.providers.config.ConfigSection;
+import com.elvenide.structures.CoreMock;
+import com.elvenide.structures.ElvenideStructures;
+import com.elvenide.structures.doors.DoorManager;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ElevatorTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private MockedStatic<Core> mockedCore;
+    private MockedStatic<ElvenideStructures> mockedStructures;
+    private ConfigSection config;
+    private DoorManager doorManager;
+    private ElevatorManager elevatorManager;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        mockedCore = CoreMock.mockCore();
+        
+        config = mock(ConfigSection.class);
+        doorManager = mock(DoorManager.class);
+        elevatorManager = mock(ElevatorManager.class);
+        
+        mockedStructures = Mockito.mockStatic(ElvenideStructures.class);
+        mockedStructures.when(ElvenideStructures::doors).thenReturn(doorManager);
+        mockedStructures.when(ElvenideStructures::elevators).thenReturn(elevatorManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedCore.close();
+        mockedStructures.close();
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testElevatorBasicGetters() {
+        when(config.getInt("base-level")).thenReturn(100);
+        when(config.getInt("current-level", 100)).thenReturn(100);
+        when(config.getInt("dest-level")).thenReturn(110);
+        when(config.getDouble("speed", 1)).thenReturn(1.0);
+        when(config.getName()).thenReturn("test-elevator");
+
+        Elevator elevator = new Elevator(config);
+        
+        assertEquals(100, elevator.getBaseY());
+        assertEquals(100, elevator.getCurrentY());
+        assertEquals(110, elevator.getDestinationY());
+        assertEquals(1.0, elevator.getSpeed());
+        assertEquals("test-elevator", elevator.getName());
+    }
+
+    @Test
+    void testMove() {
+        when(config.getInt("base-level")).thenReturn(100);
+        when(config.getInt("current-level", 100)).thenReturn(100);
+        when(config.getInt("dest-level")).thenReturn(110);
+        when(config.getDouble("speed", 1)).thenReturn(1.0);
+        
+        // Mock carriage locations
+        ConfigSection locsSection = mock(ConfigSection.class);
+        when(config.contains("locations")).thenReturn(true);
+        when(config.getSectionOrThrow("locations")).thenReturn(locsSection);
+        when(locsSection.getKeys()).thenReturn(new HashSet<>(Collections.singletonList("0_100_0")));
+        Location loc = new Location(world, 0, 100, 0);
+        loc.getBlock().setType(Material.STONE);
+        when(locsSection.getLocation("0_100_0")).thenReturn(loc);
+
+        Elevator elevator = new Elevator(config);
+        
+        assertFalse(elevator.isMoving());
+        elevator.move();
+        assertTrue(elevator.isMoving());
+    }
+
+    @Test
+    void testIsNearby() {
+        when(config.getInt("base-level")).thenReturn(100);
+        when(config.getInt("current-level", 100)).thenReturn(100);
+        when(config.getInt("dest-level")).thenReturn(110);
+        
+        ConfigSection locsSection = mock(ConfigSection.class);
+        when(config.contains("locations")).thenReturn(true);
+        when(config.getSectionOrThrow("locations")).thenReturn(locsSection);
+        when(locsSection.getKeys()).thenReturn(new HashSet<>(Collections.singletonList("0_100_0")));
+        Location loc = new Location(world, 0, 100, 0);
+        loc.getBlock().setType(Material.STONE);
+        when(locsSection.getLocation("0_100_0")).thenReturn(loc);
+        
+        when(elevatorManager.getConfiguredConnectionRange(any())).thenReturn(5.0);
+
+        Elevator elevator = new Elevator(config);
+        
+        assertTrue(elevator.isNearby(new Location(world, 0, 100, 0)));
+        assertFalse(elevator.isNearby(new Location(world, 10, 100, 10)));
+    }
+}

--- a/tests/com/elvenide/structures/elevators/ElevatorUtilsTest.java
+++ b/tests/com/elvenide/structures/elevators/ElevatorUtilsTest.java
@@ -1,0 +1,96 @@
+package com.elvenide.structures.elevators;
+
+import com.elvenide.structures.ElvenideStructures;
+import com.elvenide.structures.doors.DoorManager;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ElevatorUtilsTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private DoorManager doorManager;
+    private MockedStatic<ElvenideStructures> mockedStructures;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        doorManager = mock(DoorManager.class);
+        mockedStructures = Mockito.mockStatic(ElvenideStructures.class);
+        mockedStructures.when(ElvenideStructures::doors).thenReturn(doorManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedStructures != null) {
+            mockedStructures.close();
+        }
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testIsSolid() {
+        Block stone = world.getBlockAt(0, 100, 0);
+        stone.setType(Material.STONE);
+        assertTrue(ElevatorUtils.isSolid(stone));
+
+        Block barrier = world.getBlockAt(1, 100, 0);
+        barrier.setType(Material.BARRIER);
+        assertFalse(ElevatorUtils.isSolid(barrier));
+
+        Block grass = world.getBlockAt(3, 100, 0);
+        grass.setType(Material.TALL_GRASS);
+        assertFalse(ElevatorUtils.isSolid(grass));
+
+        Block doorBlock = world.getBlockAt(4, 100, 0);
+        doorBlock.setType(Material.STONE);
+        when(doorManager.isDoorBlock(doorBlock.getLocation())).thenReturn(true);
+        assertFalse(ElevatorUtils.isSolid(doorBlock));
+    }
+
+    @Test
+    void testIsWalkable() {
+        Block air = world.getBlockAt(0, 100, 0);
+        air.setType(Material.AIR);
+        assertTrue(ElevatorUtils.isWalkable(air));
+
+        Block stone = world.getBlockAt(1, 100, 0);
+        stone.setType(Material.STONE);
+        assertFalse(ElevatorUtils.isWalkable(stone));
+
+        Block oakDoor = world.getBlockAt(3, 100, 0);
+        oakDoor.setType(Material.OAK_DOOR);
+        assertTrue(ElevatorUtils.isWalkable(oakDoor));
+
+        Block doorBlock = world.getBlockAt(6, 100, 0);
+        doorBlock.setType(Material.STONE);
+        when(doorManager.isDoorBlock(doorBlock.getLocation())).thenReturn(true);
+        assertTrue(ElevatorUtils.isWalkable(doorBlock));
+    }
+
+    @Test
+    void testFreezeUnfreezePassengerMovement() {
+        Player player = server.addPlayer();
+        
+        ElevatorUtils.freezePassengerMovement(player);
+        assertTrue(player.getAllowFlight());
+        assertTrue(player.isFlying());
+
+        ElevatorUtils.unfreezePassengerMovement(player);
+        assertFalse(player.isFlying());
+    }
+}

--- a/tests/com/elvenide/structures/elevators/events/EventTest.java
+++ b/tests/com/elvenide/structures/elevators/events/EventTest.java
@@ -1,0 +1,24 @@
+package com.elvenide.structures.elevators.events;
+
+import com.elvenide.structures.elevators.Elevator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class EventTest {
+
+    @Test
+    void testElevatorEndEvent() {
+        Elevator elevator = mock(Elevator.class);
+        ElevatorEndEvent event = new ElevatorEndEvent(elevator);
+        assertEquals(elevator, event.elevator());
+    }
+
+    @Test
+    void testElevatorStartEvent() {
+        Elevator elevator = mock(Elevator.class);
+        ElevatorStartEvent event = new ElevatorStartEvent(elevator);
+        assertEquals(elevator, event.elevator());
+    }
+}

--- a/tests/com/elvenide/structures/selection/SelectionTest.java
+++ b/tests/com/elvenide/structures/selection/SelectionTest.java
@@ -1,0 +1,96 @@
+package com.elvenide.structures.selection;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelectionTest {
+
+    private ServerMock server;
+    private WorldMock world;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testSelection() {
+        Location pos1 = new Location(world, 0, 100, 0);
+        Location pos2 = new Location(world, 2, 102, 2);
+
+        // Set some blocks to be non-air
+        world.getBlockAt(0, 100, 0).setType(Material.STONE);
+        world.getBlockAt(1, 101, 1).setType(Material.STONE);
+        world.getBlockAt(2, 102, 2).setType(Material.STONE);
+
+        Selection selection = new Selection(pos1, pos2);
+
+        List<Location> locations = new ArrayList<>();
+        selection.forEach(locations::add);
+
+        assertEquals(3, locations.size());
+        assertTrue(locations.contains(new Location(world, 0, 100, 0)));
+        assertTrue(locations.contains(new Location(world, 1, 101, 1)));
+        assertTrue(locations.contains(new Location(world, 2, 102, 2)));
+        assertEquals(world, selection.getWorld());
+    }
+
+    @Test
+    void testSelectionEmpty() {
+        Location pos1 = new Location(world, 0, 100, 0);
+        Location pos2 = new Location(world, 1, 101, 1);
+
+        // All blocks are air by default
+        Selection selection = new Selection(pos1, pos2);
+
+        List<Location> locations = new ArrayList<>();
+        selection.forEach(locations::add);
+
+        assertEquals(0, locations.size());
+        assertEquals(10000, selection.getMinimumY());
+    }
+
+    @Test
+    void testTertiaryPosition() {
+        Location pos1 = new Location(world, 0, 100, 0);
+        Location pos2 = new Location(world, 0, 100, 0);
+        Selection selection = new Selection(pos1, pos2);
+
+        assertNull(selection.getTertiaryPosition());
+
+        Location tert = new Location(world, 105, 105, 105);
+        selection.setTertiaryPosition(tert);
+
+        assertEquals(tert, selection.getTertiaryPosition());
+    }
+
+    @Test
+    void testMinimumY() {
+        Location pos1 = new Location(world, 0, 110, 0);
+        Location pos2 = new Location(world, 0, 120, 0);
+
+        world.getBlockAt(0, 115, 0).setType(Material.STONE);
+        world.getBlockAt(0, 118, 0).setType(Material.STONE);
+
+        Selection selection = new Selection(pos1, pos2);
+
+        assertEquals(115, selection.getMinimumY());
+    }
+}

--- a/tests/com/elvenide/structures/selection/SelectionVisualizerTest.java
+++ b/tests/com/elvenide/structures/selection/SelectionVisualizerTest.java
@@ -1,0 +1,90 @@
+package com.elvenide.structures.selection;
+
+import com.elvenide.structures.CoreMock;
+import com.elvenide.structures.ElvenideStructures;
+import com.elvenide.structures.elevators.ElevatorManager;
+import com.elvenide.core.Core;
+import com.elvenide.core.providers.config.Config;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SelectionVisualizerTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private MockedStatic<Core> mockedCore;
+    private MockedStatic<ElvenideStructures> mockedStructures;
+    private ElevatorManager elevatorManager;
+    private Config elevatorConfig;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        mockedCore = CoreMock.mockCore();
+        
+        elevatorManager = mock(ElevatorManager.class);
+        elevatorConfig = mock(Config.class);
+        when(elevatorManager.getConfiguration(any())).thenReturn(elevatorConfig);
+        when(elevatorConfig.getBoolean(any(), any(Boolean.class))).thenReturn(true);
+        when(elevatorConfig.getString(any(), any())).thenReturn("GREEN");
+
+        mockedStructures = Mockito.mockStatic(ElvenideStructures.class);
+        mockedStructures.when(ElvenideStructures::elevators).thenReturn(elevatorManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedCore.close();
+        mockedStructures.close();
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testGetNew() {
+        Player player = server.addPlayer();
+        Selection selection = mock(Selection.class);
+        when(selection.getWorld()).thenReturn(world);
+
+        SelectionVisualizer visualizer = SelectionVisualizer.getNew(selection, player);
+        assertNotNull(visualizer);
+        
+        SelectionVisualizer same = SelectionVisualizer.getExisting(player);
+        assertEquals(visualizer, same);
+        
+        SelectionVisualizer next = SelectionVisualizer.getNew(selection, player);
+        assertNotEquals(visualizer, next);
+    }
+
+    @Test
+    void testCreateAndRemove() {
+        Player player = server.addPlayer();
+        Location pos1 = new Location(world, 0, 100, 0);
+        Location pos2 = new Location(world, 0, 100, 0);
+        Selection selection = new Selection(pos1, pos2); // contains 0 blocks if air
+        
+        // Let's make it contain one block
+        world.getBlockAt(0, 100, 0).setType(org.bukkit.Material.STONE);
+        selection = new Selection(pos1, pos2);
+
+        SelectionVisualizer visualizer = SelectionVisualizer.getNew(selection, player);
+        visualizer.create();
+        
+        // Removed Core.tasks verification
+        
+        visualizer.remove();
+    }
+}

--- a/tests/com/elvenide/structures/selection/events/SelectionEventTest.java
+++ b/tests/com/elvenide/structures/selection/events/SelectionEventTest.java
@@ -1,0 +1,27 @@
+package com.elvenide.structures.selection.events;
+
+import com.elvenide.structures.selection.Selection;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class SelectionEventTest {
+
+    @Test
+    void testSelectionEvent() {
+        Selection selection = mock(Selection.class);
+        Player player = mock(Player.class);
+        SelectionEvent event = new SelectionEvent(selection, player);
+        assertEquals(selection, event.selection());
+        assertEquals(player, event.selector());
+    }
+
+    @Test
+    void testSelectionCancelEvent() {
+        Player player = mock(Player.class);
+        SelectionCancelEvent event = new SelectionCancelEvent(player);
+        assertEquals(player, event.player());
+    }
+}

--- a/tests/com/elvenide/structures/switches/SwitchListenerTest.java
+++ b/tests/com/elvenide/structures/switches/SwitchListenerTest.java
@@ -1,0 +1,85 @@
+package com.elvenide.structures.switches;
+
+import com.elvenide.structures.StructureManager;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SwitchListenerTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private SwitchListener listener;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("test");
+        listener = new SwitchListener();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testPressurePlatePress() {
+        Player player = server.addPlayer();
+        Location loc = new Location(world, 0, 100, 0);
+        Block block = world.getBlockAt(loc);
+        block.setType(Material.STONE_PRESSURE_PLATE);
+
+        PlayerInteractEvent event = new PlayerInteractEvent(player, Action.PHYSICAL, null, block, null);
+        
+        try (MockedStatic<StructureManager> mockedManager = Mockito.mockStatic(StructureManager.class)) {
+            listener.onSwitchPress(event);
+            mockedManager.verify(() -> StructureManager.useSwitch(player, loc));
+        }
+    }
+
+    @Test
+    void testButtonPress() {
+        Player player = server.addPlayer();
+        Location loc = new Location(world, 0, 100, 0);
+        Block block = world.getBlockAt(loc);
+        block.setType(Material.OAK_BUTTON);
+
+        PlayerInteractEvent event = new PlayerInteractEvent(player, Action.RIGHT_CLICK_BLOCK, null, block, null);
+        
+        try (MockedStatic<StructureManager> mockedManager = Mockito.mockStatic(StructureManager.class)) {
+            listener.onSwitchPress(event);
+            // location = location.clone().subtract(0, 1, 0);
+            mockedManager.verify(() -> StructureManager.useSwitch(player, loc.clone().subtract(0, 1, 0)));
+        }
+    }
+
+    @Test
+    void testIrrelevantInteraction() {
+        Player player = server.addPlayer();
+        Location loc = new Location(world, 0, 100, 0);
+        Block block = world.getBlockAt(loc);
+        block.setType(Material.STONE);
+
+        PlayerInteractEvent event = new PlayerInteractEvent(player, Action.LEFT_CLICK_BLOCK, null, block, null);
+        
+        try (MockedStatic<StructureManager> mockedManager = Mockito.mockStatic(StructureManager.class)) {
+            listener.onSwitchPress(event);
+            mockedManager.verify(() -> StructureManager.useSwitch(any(), any()), never());
+        }
+    }
+}

--- a/testserver/eula.txt
+++ b/testserver/eula.txt
@@ -1,0 +1,1 @@
+eula=true

--- a/testserver/start.bat
+++ b/testserver/start.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:loop
+
+java -Xms4096M -Xmx4096M -XX:+AlwaysPreTouch -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled -XX:+PerfDisableSharedMem -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=8M -XX:G1HeapWastePercent=5 -XX:G1MaxNewSizePercent=40 -XX:G1MixedGCCountTarget=4 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1NewSizePercent=30 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:G1ReservePercent=20 -XX:InitiatingHeapOccupancyPercent=15 -XX:MaxGCPauseMillis=200 -XX:MaxTenuringThreshold=1 -XX:SurvivorRatio=32 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar server.jar nogui
+
+pause
+
+goto loop
+
+pause


### PR DESCRIPTION
Fixes the issue where elevator passengers and blocks would move out of sync or get dislodged upon reaching the destination floor. This is done by correctly mapping out and applying the partial distance moved on the final tick of the elevator movement and snapping final entity teleports and block data to the exact destination coordinate (`targetY`) to circumvent floating point `Math.floor` behavior anomalies.

---
*PR created automatically by Jules for task [8199191862865322374](https://jules.google.com/task/8199191862865322374) started by @Elvenide*